### PR TITLE
Fix to allow password to be remembered for 5 minutes when Enter is pressed

### DIFF
--- a/src/all/data/js/masterPassword/masterPassword.js
+++ b/src/all/data/js/masterPassword/masterPassword.js
@@ -252,8 +252,7 @@ $(function () {
 
     // The user presses enter.
     if (keycode == 13) {
-      var masterPassword = $masterPasswordField.val();
-      submitMasterPassword(masterPassword);
+      submitButtonClicked();
     }
     // The user presses escape.
     else if (keycode == 27) {


### PR DESCRIPTION
Fixes issue #173 (see https://github.com/passbolt/passbolt_api/issues/173)

(This is a very simple bugfix involving a change to two lines of code.)

## Fix to allow password to be remembered for 5 minutes when Enter is pressed

This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning
