### PR TITLE
Match lower case filenames in require paths

### DIFF
--- a/src/all/background_page/controller/informCallToActionController/informCallToActionController.js
+++ b/src/all/background_page/controller/informCallToActionController/informCallToActionController.js
@@ -12,7 +12,7 @@
  * @since         3.3.0
  */
 const Worker = require('../../model/worker');
-const {QuickAccessService} = require("../../service/ui/QuickAccess.service");
+const {QuickAccessService} = require("../../service/ui/quickAccess.service");
 const {ResourceModel} = require('../../model/resource/resourceModel');
 const GpgAuth = require('../../model/gpgauth').GpgAuth;
 const {User} = require('../../model/user');

--- a/src/all/background_page/model/locale/localeModel.js
+++ b/src/all/background_page/model/locale/localeModel.js
@@ -16,7 +16,7 @@ const Config = require('../config');
 const {i18n} = require("../../sdk/i18n");
 const {LocalesCollection} = require("../entity/locale/localesCollection");
 const {LocaleEntity} = require("../entity/locale/localeEntity");
-const {OrganizationSettingsModel} = require("../organizationSettings/OrganizationSettingsModel");
+const {OrganizationSettingsModel} = require("../organizationSettings/organizationSettingsModel");
 
 class LocaleModel {
   /**


### PR DESCRIPTION
This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [x] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What I did
When I tried to build the extension, two files could not be found. The reason for this were two mismatches between the case of the file path and the actual file name (and me using a case-sensitive file system). Hopefully, this little adjustment comes in useful.
