### PR TITLE
Allow adding a shortcut for Quick access in Firefox

### DIFF
--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -29,6 +29,7 @@
     "default_popup": "webAccessibleResources/quickaccess.html?passbolt=quickaccess"
   },
   "commands": {
+    "_execute_browser_action": {},
     "passbolt-open": {
       "suggested_key": {
         "default": "Alt+Shift+P",


### PR DESCRIPTION
## Allow adding a shortcut for Quick access in Firefox

This pull request is a (multiple allowed):

* [ ] bug fix
* [ ] change of existing behavior
* [x] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did
I've added a line to the manifest used in Firefox to allow configuring a shortcut for the extension's toolbar button. This is similar to what Chrome allows by default.

I have not set a default shortcut, to match how the extension works in Chrome.

Community forum thread requesting this feature: https://community.passbolt.com/t/firefox-keyboard-shortcut-missing/4408
I believe you are tracking this feature internally as PB-9728.

I have tested this change manually in Firefox 120.0 on Ubuntu. The quick access popup shows up, with the search bar focused.