### PR TITLE
feat(quickaccess): opt-in launch-and-autofill + lock-extension shortcut

### DIFF
--- a/src/all/background_page/controller/autofill/launchResourceController.js
+++ b/src/all/background_page/controller/autofill/launchResourceController.js
@@ -1,0 +1,262 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+
+import ResourceModel from "../../model/resource/resourceModel";
+import ResourceTypeModel from "../../model/resourceType/resourceTypeModel";
+import GetPassphraseService from "../../service/passphrase/getPassphraseService";
+import WorkerService from "../../service/worker/workerService";
+import GetDecryptedUserPrivateKeyService from "../../service/account/getDecryptedUserPrivateKeyService";
+import DecryptAndParseResourceSecretService from "../../service/secret/decryptAndParseResourceSecretService";
+import FindSecretService from "../../service/secret/findSecretService";
+import BrowserTabService from "../../service/ui/browserTab.service";
+import AutofillSettingsService from "../../service/autofill/autofillSettingsService";
+import Validator from "validator";
+
+const BLANK_TAB_URLS = ["about:blank", "about:newtab", "chrome://newtab/", ""];
+
+/**
+ * Launches a resource: navigates a tab to the resource's stored URI and autofills the login form
+ * once the page has loaded, when the user has enabled "autofill on launch".
+ *
+ * Security notes:
+ * - This controller deliberately does NOT submit the form. Auto-submitting credentials without a
+ *   human seeing the loaded page is the gating behaviour Passbolt intentionally keeps; it is out of
+ *   scope here. The fill is a value the user can inspect and undo.
+ * - Before decrypting or filling, the loaded page's origin is verified on the trusted (service
+ *   worker) side against the resource's stored origin, using the browser-verified sender URL of the
+ *   content-script worker, not a URL computed before navigation. This defends against a redirect,
+ *   DNS/MITM, or a re-registered/expired domain causing the credential to be filled into another
+ *   origin.
+ * - Only https resource URIs are launched-and-filled (plaintext http is refused for this path).
+ */
+class LaunchResourceController {
+  /**
+   * LaunchResourceController constructor
+   * @param {Worker} worker
+   * @param {string} requestId
+   * @param {ApiClientOptions} apiClientOptions the api client options
+   * @param {AccountEntity} account The account associated to the worker.
+   */
+  constructor(worker, requestId, apiClientOptions, account) {
+    this.worker = worker;
+    this.requestId = requestId;
+    this.resourceModel = new ResourceModel(apiClientOptions, account);
+    this.findSecretService = new FindSecretService(account, apiClientOptions);
+    this.resourceTypeModel = new ResourceTypeModel(apiClientOptions);
+    this.getPassphraseService = new GetPassphraseService(account);
+  }
+
+  /**
+   * Wrap the exec to emit the request outcome on the worker port.
+   * Non-abort errors are sanitised to a generic message so decryption/secret error detail is never
+   * forwarded to the popup.
+   * @param {string} resourceId A resource identifier
+   * @return {Promise<void>}
+   */
+  async _exec(resourceId, openerTabId) {
+    try {
+      await this.exec(resourceId, openerTabId);
+      this.worker.port.emit(this.requestId, "SUCCESS");
+    } catch (error) {
+      console.error(error);
+      const safeError =
+        error?.name === "UserAbortsOperationError"
+          ? error
+          : new Error("Unable to launch and autofill the resource.");
+      this.worker.port.emit(this.requestId, "ERROR", safeError);
+    }
+  }
+
+  /**
+   * Launch a resource: navigate to its primary URI and autofill the login form once the page loaded,
+   * when "autofill on launch" is enabled.
+   *
+   * @param {string} resourceId A resource identifier
+   * @param {number} openerTabId The id of the tab that was active when the popup opened
+   * @return {Promise<void>}
+   * @throws {Error} if autofill on launch is disabled, the URI is invalid, the loaded origin does not
+   *   match the resource origin, or decryption fails.
+   */
+  async exec(resourceId, openerTabId) {
+    // Validate the caller-supplied identifier at the boundary (defence in depth) before any work.
+    if (!Validator.isUUID(resourceId)) {
+      throw new Error("The resource id is not a valid identifier.");
+    }
+
+    const settings = await AutofillSettingsService.get();
+    // Guard: only reachable when autofill on launch is enabled. When disabled the popup uses a plain
+    // anchor and never dispatches this request.
+    if (!settings.autofillOnLaunch) {
+      throw new Error("Autofill on launch is not enabled.");
+    }
+
+    const resource = await this.resourceModel.getById(resourceId);
+    const uri = resource?.metadata?.uris?.[0];
+    this.assertHttpsUrl(uri);
+    const expectedOrigin = new URL(uri).origin;
+
+    // Navigate (reuse the opener tab when blank, else open a new tab) and bind to the exact target tab.
+    const tabId = await this.navigateToUri(uri, openerTabId);
+
+    /*
+     * Wait for the web integration content script on the destination page. Time-boxed to ~3s
+     * (30 × 100ms) so a destination that never loads the integration (e.g. a non-HTML response)
+     * fails fast instead of hanging the launch on the default 5s budget.
+     */
+    await WorkerService.waitExists("WebIntegration", tabId, 30);
+    const webIntegrationWorker = await WorkerService.get("WebIntegration", tabId);
+
+    /*
+     * Trusted-side origin binding (critical). Verify the page that actually loaded matches the
+     * resource's stored origin BEFORE decrypting or filling, using the browser-verified sender URL
+     * of the content-script worker. Refuse on mismatch. A redirect / DNS / takeover that sent the
+     * tab elsewhere must not receive the credential.
+     */
+    this.assertWorkerOriginMatches(webIntegrationWorker, expectedOrigin);
+
+    /*
+     * Get the passphrase from the quickaccess in detached mode if not stored in memory.
+     * Works standalone and prompts the user when the vault is locked.
+     */
+    const passphrase = await this.getPassphraseService.requestPassphraseFromQuickAccess();
+
+    // Decrypt and parse the resource secret, mirroring AutofillController.exec().
+    const secret = await this.findSecretService.findByResourceId(resourceId);
+    const secretSchema = await this.resourceTypeModel.getSecretSchemaById(resource.resourceTypeId);
+    const privateKey = await GetDecryptedUserPrivateKeyService.getKey(passphrase);
+    const plaintextSecret = await DecryptAndParseResourceSecretService.decryptAndParse(
+      secret,
+      secretSchema,
+      privateKey,
+    );
+
+    const username = resource.metadata?.username || "";
+    const password = plaintextSecret?.password || "";
+    const totp = plaintextSecret?.totp;
+
+    /*
+     * TOCTOU re-check (critical). The passphrase prompt above can take seconds-to-minutes, during
+     * which the tab could navigate (same-document change, or a worker reused for a new page). Re-fetch
+     * the worker and re-verify its browser-verified origin immediately before dispatching the
+     * credential, so the fill cannot land on an origin that differs from the resource's.
+     */
+    const fillWorker = await WorkerService.get("WebIntegration", tabId);
+    this.assertWorkerOriginMatches(fillWorker, expectedOrigin);
+
+    /*
+     * Dispatch the fill to the web integration content script via the standalone quickaccess fill
+     * path (autofills without a prior in-form-menu interaction, required for a freshly navigated
+     * page). No submit is requested; the form is filled, not submitted.
+     */
+    await fillWorker.port.request("passbolt.quickaccess.fill-form", username, password, totp, uri);
+  }
+
+  /**
+   * Navigate to the given URI, reusing the opener tab when it is blank, otherwise opening a new tab.
+   *
+   * The "opener tab" is the tab that was active when the popup opened, not the currently focused tab,
+   * which from the service worker is the popup's own context. The destination tab id is taken from the
+   * navigation API result (not re-queried), so the fill is bound to the exact tab that was navigated.
+   * @param {string} uri The validated https URI to navigate to.
+   * @param {number} openerTabId The id of the tab that was active when the popup opened.
+   * @return {Promise<number>} The destination tab id.
+   * @private
+   */
+  async navigateToUri(uri, openerTabId) {
+    const targetTab = await this.resolveTargetTab(openerTabId);
+    const targetUrl = targetTab?.url || targetTab?.pendingUrl || "";
+    const isBlankTab = BLANK_TAB_URLS.includes(targetUrl) || !/^https?:/i.test(targetUrl);
+
+    if (targetTab && isBlankTab) {
+      const updatedTab = await browser.tabs.update(targetTab.id, { url: uri });
+      return updatedTab.id;
+    }
+
+    const createdTab = await browser.tabs.create({ url: uri });
+    return createdTab.id;
+  }
+
+  /**
+   * Resolve the tab the user was on when they triggered the launch. Tries the popup's opener tab
+   * first, then the active tab of the last-focused / current window (mirrors ToolbarService).
+   * @param {number|string} openerTabId
+   * @return {Promise<object|null>}
+   * @private
+   */
+  async resolveTargetTab(openerTabId) {
+    if (openerTabId !== undefined && openerTabId !== null && openerTabId !== "") {
+      try {
+        const tab = await BrowserTabService.getById(openerTabId);
+        if (tab) {
+          return tab;
+        }
+      } catch (error) {
+        // fall through to the active-tab queries
+      }
+    }
+    for (const queryOptions of [{ active: true, lastFocusedWindow: true }, { active: true, currentWindow: true }]) {
+      try {
+        const tabs = await browser.tabs.query(queryOptions);
+        if (tabs?.[0]) {
+          return tabs[0];
+        }
+      } catch (error) {
+        // try the next query
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Assert that the content-script worker's browser-verified page origin matches the expected origin.
+   * @param {Worker} webIntegrationWorker
+   * @param {string} expectedOrigin The resource URI origin.
+   * @throws {Error} if the loaded origin cannot be determined or does not match.
+   * @private
+   */
+  assertWorkerOriginMatches(webIntegrationWorker, expectedOrigin) {
+    const senderUrl = webIntegrationWorker?.port?._port?.sender?.url;
+    let landedOrigin;
+    try {
+      landedOrigin = new URL(senderUrl).origin;
+    } catch (error) {
+      throw new Error("Could not determine the loaded page origin for autofill.");
+    }
+    if (landedOrigin !== expectedOrigin) {
+      throw new Error("Refusing to autofill: the loaded page origin does not match the resource URL.");
+    }
+  }
+
+  /**
+   * Assert that the given value is a valid https URL. Plaintext http is refused for launch-and-fill.
+   * @param {string} urlString
+   * @throws {Error} if the value is not a valid https URL.
+   * @private
+   */
+  assertHttpsUrl(urlString) {
+    const validationOption = {
+      require_tld: false,
+      require_host: true,
+      require_protocol: true,
+      require_valid_protocol: true,
+      protocols: ["https"],
+    };
+
+    if (typeof urlString !== "string" || !Validator.isURL(urlString, validationOption)) {
+      throw new Error("The resource does not have a valid https URL to launch.");
+    }
+  }
+}
+
+export default LaunchResourceController;

--- a/src/all/background_page/controller/autofill/launchResourceController.test.js
+++ b/src/all/background_page/controller/autofill/launchResourceController.test.js
@@ -1,0 +1,287 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+
+import AccountEntity from "../../model/entity/account/accountEntity";
+import LaunchResourceController from "./launchResourceController";
+import AutofillSettingsService from "../../service/autofill/autofillSettingsService";
+import WorkerService from "../../service/worker/workerService";
+import BrowserTabService from "../../service/ui/browserTab.service";
+import GetDecryptedUserPrivateKeyService from "../../service/account/getDecryptedUserPrivateKeyService";
+import EncryptMessageService from "../../service/crypto/encryptMessageService";
+import { OpenpgpAssertion } from "../../utils/openpgp/openpgpAssertions";
+import { defaultAccountDto } from "../../model/entity/account/accountEntity.test.data";
+import { defaultApiClientOptions } from "passbolt-styleguide/src/shared/lib/apiClient/apiClientOptions.test.data";
+import { defaultResourceDto } from "passbolt-styleguide/src/shared/models/entity/resource/resourceEntity.test.data";
+import { resourceTypePasswordDescriptionTotpDto } from "passbolt-styleguide/src/shared/models/entity/resourceType/resourceTypeEntity.test.data";
+import { minimalDto } from "passbolt-styleguide/src/shared/models/entity/secret/secretEntity.test.data";
+import SecretEntity from "passbolt-styleguide/src/shared/models/entity/secret/secretEntity";
+import { defaultTotpDto } from "../../model/entity/totp/totpDto.test.data";
+import { pgpKeys } from "passbolt-styleguide/test/fixture/pgpKeys/keys";
+import { readWorker } from "../../model/entity/worker/workerEntity.test.data";
+import { mockPort } from "../../sdk/port/portManager.test.data";
+import Port from "../../sdk/port";
+import UserAbortsOperationError from "../../error/userAbortsOperationError";
+import { v4 as uuidv4 } from "uuid";
+
+const account = new AccountEntity(defaultAccountDto());
+const RESOURCE_ID = uuidv4();
+const RESOURCE_URI = "https://example.com/login";
+
+/**
+ * Build a controller with the worker port whose verified sender.url is `landedUrl`,
+ * and stub the decrypt chain + navigation. Returns the controller, its worker port, and the resource.
+ */
+async function setup({ autofillOnLaunch = true, landedUrl = RESOURCE_URI, uri = RESOURCE_URI } = {}) {
+  const publicKey = await OpenpgpAssertion.readKeyOrFail(pgpKeys.ada.public);
+  const privateKey = await OpenpgpAssertion.readKeyOrFail(pgpKeys.ada.private_decrypted);
+  const plaintextSecretDto = { totp: defaultTotpDto(), password: "password-test", description: "description-test" };
+  const secretDto = minimalDto({
+    data: await EncryptMessageService.encrypt(JSON.stringify(plaintextSecretDto), publicKey),
+  });
+  const schema = resourceTypePasswordDescriptionTotpDto().definition.secret;
+
+  const resource = defaultResourceDto();
+  resource.metadata.uris = [uri];
+  resource.metadata.username = "ada@passbolt.com";
+
+  const callerWorker = readWorker();
+  const controller = new LaunchResourceController(callerWorker, uuidv4(), defaultApiClientOptions(), account);
+
+  // The web-integration worker on the destination tab; its sender.url is the trusted "landed" origin.
+  const integrationPort = new Port(mockPort({ name: "WebIntegration", tabId: 42, url: landedUrl }));
+
+  jest.spyOn(AutofillSettingsService, "get").mockResolvedValue({ autofillOnLaunch });
+  jest.spyOn(WorkerService, "waitExists").mockResolvedValue(undefined);
+  jest.spyOn(WorkerService, "get").mockResolvedValue({ port: integrationPort });
+  jest.spyOn(GetDecryptedUserPrivateKeyService, "getKey").mockResolvedValue(privateKey);
+  jest.spyOn(controller.resourceModel, "getById").mockResolvedValue(resource);
+  jest.spyOn(controller.findSecretService, "findByResourceId").mockResolvedValue(new SecretEntity(secretDto));
+  jest.spyOn(controller.resourceTypeModel, "getSecretSchemaById").mockResolvedValue(schema);
+  jest
+    .spyOn(controller.getPassphraseService, "requestPassphraseFromQuickAccess")
+    .mockResolvedValue(pgpKeys.ada.passphrase);
+  jest.spyOn(integrationPort, "request").mockResolvedValue("SUCCESS");
+
+  // Navigation: a non-blank opener tab so navigateToUri opens a new tab (id 42).
+  jest.spyOn(BrowserTabService, "getById").mockResolvedValue({ id: 7, url: "https://other.com" });
+  global.browser.tabs.create = jest.fn().mockResolvedValue({ id: 42 });
+  global.browser.tabs.update = jest.fn().mockResolvedValue({ id: 7 });
+
+  return { controller, integrationPort, resource, plaintextSecretDto };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("LaunchResourceController", () => {
+  describe("::exec", () => {
+    it("rejects an invalid (non-uuid) resource id before doing any work", async () => {
+      expect.assertions(3);
+      const { controller } = await setup();
+
+      await expect(controller.exec("not-a-uuid", 7)).rejects.toThrow("not a valid identifier");
+      // Boundary validation happens before reading settings or the resource.
+      expect(AutofillSettingsService.get).not.toHaveBeenCalled();
+      expect(controller.resourceModel.getById).not.toHaveBeenCalled();
+    });
+
+    it("refuses to decrypt or fill when the loaded page origin does not match the resource origin", async () => {
+      expect.assertions(3);
+      const { controller, integrationPort } = await setup({ landedUrl: "https://evil.com/login" });
+
+      await expect(controller.exec(RESOURCE_ID, 7)).rejects.toThrow("does not match the resource");
+      // No decryption and no fill on mismatch.
+      expect(controller.findSecretService.findByResourceId).not.toHaveBeenCalled();
+      expect(integrationPort.request).not.toHaveBeenCalled();
+    });
+
+    it("throws and does nothing when autofill on launch is disabled", async () => {
+      expect.assertions(2);
+      const { controller } = await setup({ autofillOnLaunch: false });
+
+      await expect(controller.exec(RESOURCE_ID, 7)).rejects.toThrow("Autofill on launch is not enabled");
+      expect(controller.resourceModel.getById).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-https resource URL before navigating", async () => {
+      expect.assertions(2);
+      const { controller } = await setup({ uri: "http://insecure.example.com/login" });
+
+      await expect(controller.exec(RESOURCE_ID, 7)).rejects.toThrow("valid https URL");
+      expect(WorkerService.waitExists).not.toHaveBeenCalled();
+    });
+
+    it("fills the matching page and never submits, re-checking the origin before dispatch", async () => {
+      expect.assertions(4);
+      const { controller, integrationPort, plaintextSecretDto } = await setup({ landedUrl: RESOURCE_URI });
+
+      await controller.exec(RESOURCE_ID, 7);
+
+      // Origin re-checked at dispatch time (TOCTOU): WorkerService.get called for the initial check and again before fill.
+      expect(WorkerService.get).toHaveBeenCalledTimes(2);
+      expect(integrationPort.request).toHaveBeenCalledTimes(1);
+      expect(integrationPort.request).toHaveBeenCalledWith(
+        "passbolt.quickaccess.fill-form",
+        "ada@passbolt.com",
+        plaintextSecretDto.password,
+        plaintextSecretDto.totp,
+        RESOURCE_URI,
+      );
+      // The fill message carries no auto-submit flag (auto-login was cut).
+      expect(integrationPort.request.mock.calls[0]).toHaveLength(5);
+    });
+
+    it("aborts the fill when the tab navigated to another origin while the passphrase was prompted (TOCTOU)", async () => {
+      expect.assertions(4);
+      const { controller, integrationPort } = await setup();
+      // First fetch (pre-passphrase check) sees the expected origin; the re-fetch at dispatch time sees another one.
+      const driftedPort = new Port(mockPort({ name: "WebIntegration", tabId: 42, url: "https://evil.com/login" }));
+      jest.spyOn(driftedPort, "request").mockResolvedValue("SUCCESS");
+      WorkerService.get.mockResolvedValueOnce({ port: integrationPort }).mockResolvedValueOnce({ port: driftedPort });
+
+      await expect(controller.exec(RESOURCE_ID, 7)).rejects.toThrow("does not match the resource");
+
+      // The re-check ran against the re-fetched worker and no fill was dispatched to either worker.
+      expect(WorkerService.get).toHaveBeenCalledTimes(2);
+      expect(integrationPort.request).not.toHaveBeenCalled();
+      expect(driftedPort.request).not.toHaveBeenCalled();
+    });
+
+    it("aborts the fill when the destination tab closed while the passphrase was prompted", async () => {
+      expect.assertions(2);
+      const { controller, integrationPort } = await setup();
+      // The worker re-fetch at dispatch time fails because the tab (and its worker) is gone.
+      WorkerService.get
+        .mockResolvedValueOnce({ port: integrationPort })
+        .mockRejectedValueOnce(new Error("Could not find worker WebIntegration for tab 42."));
+
+      await expect(controller.exec(RESOURCE_ID, 7)).rejects.toThrow("Could not find worker");
+      expect(integrationPort.request).not.toHaveBeenCalled();
+    });
+
+    it("refuses to decrypt or fill when the loaded page origin cannot be determined", async () => {
+      expect.assertions(4);
+      const { controller, integrationPort } = await setup();
+      // A worker whose browser-verified sender URL is missing must be refused, not treated as a match.
+      integrationPort._port.sender.url = undefined;
+
+      await expect(controller.exec(RESOURCE_ID, 7)).rejects.toThrow("Could not determine the loaded page origin");
+      // Refused before prompting for the passphrase, decrypting or filling.
+      expect(controller.getPassphraseService.requestPassphraseFromQuickAccess).not.toHaveBeenCalled();
+      expect(controller.findSecretService.findByResourceId).not.toHaveBeenCalled();
+      expect(integrationPort.request).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("::navigateToUri", () => {
+    it("reuses the opener tab when it is blank", async () => {
+      const { controller } = await setup();
+      BrowserTabService.getById.mockResolvedValue({ id: 7, url: "about:blank" });
+
+      const tabId = await controller.navigateToUri(RESOURCE_URI, 7);
+
+      expect(global.browser.tabs.update).toHaveBeenCalledWith(7, { url: RESOURCE_URI });
+      expect(global.browser.tabs.create).not.toHaveBeenCalled();
+      expect(tabId).toBe(7);
+    });
+
+    it("opens a new tab when the opener tab is a real http(s) page", async () => {
+      const { controller } = await setup();
+      BrowserTabService.getById.mockResolvedValue({ id: 7, url: "https://other.com" });
+
+      const tabId = await controller.navigateToUri(RESOURCE_URI, 7);
+
+      expect(global.browser.tabs.create).toHaveBeenCalledWith({ url: RESOURCE_URI });
+      expect(tabId).toBe(42);
+    });
+  });
+
+  describe("::resolveTargetTab", () => {
+    it("returns the opener tab when it resolves by id", async () => {
+      const { controller } = await setup();
+      BrowserTabService.getById.mockResolvedValue({ id: 7, url: "about:blank" });
+
+      const tab = await controller.resolveTargetTab(7);
+
+      expect(tab).toEqual({ id: 7, url: "about:blank" });
+    });
+
+    it("falls back to the active tab query when the opener id does not resolve", async () => {
+      const { controller } = await setup();
+      BrowserTabService.getById.mockRejectedValue(new Error("No tab with id"));
+      global.browser.tabs.query = jest.fn().mockResolvedValue([{ id: 99, url: "https://active.example.com" }]);
+
+      const tab = await controller.resolveTargetTab(7);
+
+      expect(BrowserTabService.getById).toHaveBeenCalledWith(7);
+      expect(tab).toEqual({ id: 99, url: "https://active.example.com" });
+    });
+
+    it("queries the active tab directly when no opener id is provided", async () => {
+      const { controller } = await setup();
+      global.browser.tabs.query = jest.fn().mockResolvedValue([{ id: 99, url: "https://active.example.com" }]);
+
+      const tab = await controller.resolveTargetTab(undefined);
+
+      expect(BrowserTabService.getById).not.toHaveBeenCalled();
+      expect(tab).toEqual({ id: 99, url: "https://active.example.com" });
+    });
+
+    it("returns null when neither the opener id nor any active-tab query resolves", async () => {
+      const { controller } = await setup();
+      BrowserTabService.getById.mockRejectedValue(new Error("No tab with id"));
+      global.browser.tabs.query = jest.fn().mockResolvedValue([]);
+
+      const tab = await controller.resolveTargetTab(7);
+
+      expect(tab).toBeNull();
+    });
+  });
+
+  describe("::_exec", () => {
+    it("sanitises non-abort errors before emitting to the popup", async () => {
+      expect.assertions(2);
+      const emit = jest.fn();
+      const controller = new LaunchResourceController({ port: { emit } }, "req-1", defaultApiClientOptions(), account);
+      jest.spyOn(AutofillSettingsService, "get").mockResolvedValue({ autofillOnLaunch: false });
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      await controller._exec(RESOURCE_ID, 7);
+
+      const emitted = emit.mock.calls.find((call) => call[1] === "ERROR");
+      expect(emitted).toBeDefined();
+      // Generic message, not the internal "Autofill on launch is not enabled." detail.
+      expect(emitted[2].message).toBe("Unable to launch and autofill the resource.");
+    });
+
+    it("passes a user abort through unsanitised so the popup can distinguish it", async () => {
+      expect.assertions(3);
+      const { controller } = await setup();
+      const emit = jest.fn();
+      controller.worker = { port: { emit } };
+      controller.getPassphraseService.requestPassphraseFromQuickAccess.mockRejectedValue(
+        new UserAbortsOperationError("The dialog has been closed."),
+      );
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      await controller._exec(RESOURCE_ID, 7);
+
+      const emitted = emit.mock.calls.find((call) => call[1] === "ERROR");
+      expect(emitted).toBeDefined();
+      expect(emitted[2].name).toBe("UserAbortsOperationError");
+      expect(emitted[2].message).toBe("The dialog has been closed.");
+    });
+  });
+});

--- a/src/all/background_page/controller/tab/openResourceUriInOpenerTabController.js
+++ b/src/all/background_page/controller/tab/openResourceUriInOpenerTabController.js
@@ -1,0 +1,115 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+
+import sanitizeUrl, { urlProtocols } from "passbolt-styleguide/src/react-extension/lib/Sanitize/sanitizeUrl";
+import BrowserTabService from "../../service/ui/browserTab.service";
+
+// Tabs considered "blank" (a freshly opened/new-tab page), safe to navigate in place instead of
+// opening yet another tab. Mirrors the list used by LaunchResourceController.
+const BLANK_TAB_URLS = ["about:blank", "about:newtab", "chrome://newtab/", ""];
+
+/**
+ * Opens a resource URI from the quickaccess WITHOUT decrypting or autofilling any secret.
+ *
+ * Unlike the stock `passbolt.tabs.open-resource-uri` (App worker) which always opens a new tab, this
+ * reuses the opener tab when it is blank (e.g. an incognito new-tab page), otherwise opens a new tab.
+ * This keeps the autofill-disabled launch consistent with the autofill-enabled launch
+ * (LaunchResourceController), which already reuses a blank opener tab.
+ *
+ * No secret is read here; http and https are both allowed (it only navigates a tab).
+ */
+export default class OpenResourceUriInOpenerTabController {
+  /**
+   * @param {Worker} worker
+   * @param {string} requestId
+   */
+  constructor(worker, requestId) {
+    this.worker = worker;
+    this.requestId = requestId;
+  }
+
+  /**
+   * Wrap exec to emit the outcome on the worker port. Errors are sanitised to a generic message.
+   * @param {string} uri
+   * @param {number} openerTabId
+   * @return {Promise<void>}
+   */
+  async _exec(uri, openerTabId) {
+    try {
+      await this.exec(uri, openerTabId);
+      this.worker.port.emit(this.requestId, "SUCCESS");
+    } catch (error) {
+      console.error(error);
+      this.worker.port.emit(this.requestId, "ERROR", new Error("Unable to open the resource URL."));
+    }
+  }
+
+  /**
+   * Sanitise the URI and navigate to it, reusing the opener tab when it is blank.
+   * @param {string} uriString
+   * @param {number} openerTabId The id of the tab that was active when the popup opened.
+   * @return {Promise<void>}
+   * @throws {Error} if the URI is not a valid http(s) URL.
+   */
+  async exec(uriString, openerTabId) {
+    const url = sanitizeUrl(uriString, {
+      whiteListedProtocols: [urlProtocols.HTTPS, urlProtocols.HTTP],
+      defaultProtocol: urlProtocols.HTTPS,
+    });
+    if (!url) {
+      throw new Error("The given URL is not valid for opening in a tab.");
+    }
+
+    const targetTab = await this.resolveTargetTab(openerTabId);
+    const targetUrl = targetTab?.url || targetTab?.pendingUrl || "";
+    const isBlankTab = BLANK_TAB_URLS.includes(targetUrl) || !/^https?:/i.test(targetUrl);
+
+    if (targetTab && isBlankTab) {
+      await browser.tabs.update(targetTab.id, { url });
+      return;
+    }
+    await browser.tabs.create({ url });
+  }
+
+  /**
+   * Resolve the tab the user was on when they triggered the launch: the popup's opener tab first,
+   * then the active tab of the last-focused / current window.
+   * @param {number|string} openerTabId
+   * @return {Promise<object|null>}
+   * @private
+   */
+  async resolveTargetTab(openerTabId) {
+    if (openerTabId !== undefined && openerTabId !== null && openerTabId !== "") {
+      try {
+        const tab = await BrowserTabService.getById(openerTabId);
+        if (tab) {
+          return tab;
+        }
+      } catch (error) {
+        // fall through to the active-tab queries
+      }
+    }
+    for (const queryOptions of [{ active: true, lastFocusedWindow: true }, { active: true, currentWindow: true }]) {
+      try {
+        const tabs = await browser.tabs.query(queryOptions);
+        if (tabs?.[0]) {
+          return tabs[0];
+        }
+      } catch (error) {
+        // try the next query
+      }
+    }
+    return null;
+  }
+}

--- a/src/all/background_page/controller/tab/openResourceUriInOpenerTabController.test.js
+++ b/src/all/background_page/controller/tab/openResourceUriInOpenerTabController.test.js
@@ -1,0 +1,106 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+
+import OpenResourceUriInOpenerTabController from "./openResourceUriInOpenerTabController";
+import BrowserTabService from "../../service/ui/browserTab.service";
+
+const URI = "https://example.com/login";
+
+function buildController() {
+  const emit = jest.fn();
+  const controller = new OpenResourceUriInOpenerTabController({ port: { emit } }, "req-1");
+  global.browser.tabs.update = jest.fn().mockResolvedValue({ id: 7 });
+  global.browser.tabs.create = jest.fn().mockResolvedValue({ id: 42 });
+  global.browser.tabs.query = jest.fn().mockResolvedValue([]);
+  return { controller, emit };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("OpenResourceUriInOpenerTabController", () => {
+  describe("::exec", () => {
+    it("reuses the opener tab when it is blank", async () => {
+      const { controller } = buildController();
+      jest.spyOn(BrowserTabService, "getById").mockResolvedValue({ id: 7, url: "about:blank" });
+
+      await controller.exec(URI, 7);
+
+      expect(global.browser.tabs.update).toHaveBeenCalledWith(7, { url: URI });
+      expect(global.browser.tabs.create).not.toHaveBeenCalled();
+    });
+
+    it("opens a new tab when the opener tab is a real http(s) page", async () => {
+      const { controller } = buildController();
+      jest.spyOn(BrowserTabService, "getById").mockResolvedValue({ id: 7, url: "https://other.com" });
+
+      await controller.exec(URI, 7);
+
+      expect(global.browser.tabs.create).toHaveBeenCalledWith({ url: URI });
+      expect(global.browser.tabs.update).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the active tab when the opener id does not resolve", async () => {
+      const { controller } = buildController();
+      jest.spyOn(BrowserTabService, "getById").mockRejectedValue(new Error("no tab"));
+      global.browser.tabs.query = jest.fn().mockResolvedValue([{ id: 99, url: "about:newtab" }]);
+
+      await controller.exec(URI, 7);
+
+      expect(global.browser.tabs.update).toHaveBeenCalledWith(99, { url: URI });
+    });
+
+    it("opens a new tab when neither the opener tab nor any active tab can be resolved", async () => {
+      const { controller } = buildController();
+      // Opener tab closed in the meantime and the active-tab queries return nothing.
+      jest.spyOn(BrowserTabService, "getById").mockRejectedValue(new Error("no tab"));
+
+      await controller.exec(URI, 7);
+
+      expect(global.browser.tabs.create).toHaveBeenCalledWith({ url: URI });
+      expect(global.browser.tabs.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid (non-http) URL", async () => {
+      const { controller } = buildController();
+
+      await expect(controller.exec("javascript:alert(1)", 7)).rejects.toThrow("not valid");
+      expect(global.browser.tabs.update).not.toHaveBeenCalled();
+      expect(global.browser.tabs.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("::_exec", () => {
+    it("emits SUCCESS on success", async () => {
+      const { controller, emit } = buildController();
+      jest.spyOn(BrowserTabService, "getById").mockResolvedValue({ id: 7, url: "about:blank" });
+
+      await controller._exec(URI, 7);
+
+      expect(emit).toHaveBeenCalledWith("req-1", "SUCCESS");
+    });
+
+    it("emits a sanitised ERROR on failure", async () => {
+      const { controller, emit } = buildController();
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      await controller._exec("javascript:alert(1)", 7);
+
+      const errorCall = emit.mock.calls.find((call) => call[1] === "ERROR");
+      expect(errorCall).toBeDefined();
+      expect(errorCall[2].message).toBe("Unable to open the resource URL.");
+    });
+  });
+});

--- a/src/all/background_page/event/autofillSettingsEvents.js
+++ b/src/all/background_page/event/autofillSettingsEvents.js
@@ -1,0 +1,42 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+import AutofillSettingsService from "../service/autofill/autofillSettingsService";
+
+/**
+ * Listens the autofill settings events.
+ *
+ * Read-only: the popup reads the `autofillOnLaunch` preference to decide the launch behaviour.
+ * Writing is done exclusively from the extension options page, which uses `chrome.storage.local`
+ * directly, so no setter is exposed over the port (smaller attack surface).
+ * @param {Worker} worker
+ */
+const listen = function (worker) {
+  /*
+   * Get the autofill on launch settings.
+   *
+   * @listens passbolt.autofill-settings.get
+   * @param requestId {uuid} The request identifier
+   */
+  worker.port.on("passbolt.autofill-settings.get", async (requestId) => {
+    try {
+      const settings = await AutofillSettingsService.get();
+      worker.port.emit(requestId, "SUCCESS", settings);
+    } catch (error) {
+      console.error(error);
+      worker.port.emit(requestId, "ERROR", new Error("Could not read the autofill settings."));
+    }
+  });
+};
+
+export const AutofillSettingsEvents = { listen };

--- a/src/all/background_page/event/autofillSettingsEvents.test.js
+++ b/src/all/background_page/event/autofillSettingsEvents.test.js
@@ -1,0 +1,75 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+
+import { AutofillSettingsEvents } from "./autofillSettingsEvents";
+import AutofillSettingsService from "../service/autofill/autofillSettingsService";
+
+/**
+ * Build a worker whose port records the registered listeners so they can be invoked, and captures
+ * everything emitted back.
+ */
+function mockWorker() {
+  const listeners = {};
+  const emitted = [];
+  const worker = {
+    port: {
+      on: (name, handler) => {
+        listeners[name] = handler;
+      },
+      emit: (...args) => emitted.push(args),
+    },
+  };
+  return { worker, listeners, emitted };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("AutofillSettingsEvents", () => {
+  it("registers only the read (get) handler; no setter is exposed over the port", () => {
+    const { worker, listeners } = mockWorker();
+
+    AutofillSettingsEvents.listen(worker);
+
+    expect(Object.keys(listeners)).toEqual(["passbolt.autofill-settings.get"]);
+    expect(listeners["passbolt.autofill-settings.set"]).toBeUndefined();
+  });
+
+  describe("passbolt.autofill-settings.get", () => {
+    it("emits SUCCESS with the persisted settings", async () => {
+      const { worker, listeners, emitted } = mockWorker();
+      jest.spyOn(AutofillSettingsService, "get").mockResolvedValue({ autofillOnLaunch: true });
+      AutofillSettingsEvents.listen(worker);
+
+      await listeners["passbolt.autofill-settings.get"]("req-1");
+
+      expect(emitted).toEqual([["req-1", "SUCCESS", { autofillOnLaunch: true }]]);
+    });
+
+    it("emits a generic ERROR (no internal detail) when the read fails", async () => {
+      const { worker, listeners, emitted } = mockWorker();
+      jest.spyOn(AutofillSettingsService, "get").mockRejectedValue(new Error("storage exploded internally"));
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      AutofillSettingsEvents.listen(worker);
+
+      await listeners["passbolt.autofill-settings.get"]("req-1");
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0][0]).toBe("req-1");
+      expect(emitted[0][1]).toBe("ERROR");
+      expect(emitted[0][2].message).toBe("Could not read the autofill settings.");
+    });
+  });
+});

--- a/src/all/background_page/event/quickAccessEvents.js
+++ b/src/all/background_page/event/quickAccessEvents.js
@@ -10,6 +10,8 @@ import FindRbacMeController from "../controller/rbac/findRbacMeController";
 import GetOrFindLoggedInUserController from "../controller/user/getOrFindLoggedInUserController";
 import GetOrFindPasswordPoliciesController from "../controller/passwordPolicies/getOrFindPasswordPoliciesController";
 import AutofillController from "../controller/autofill/AutofillController";
+import LaunchResourceController from "../controller/autofill/launchResourceController";
+import OpenResourceUriInOpenerTabController from "../controller/tab/openResourceUriInOpenerTabController";
 import GetOrFindPasswordExpirySettingsController from "../controller/passwordExpiry/getOrFindPasswordExpirySettingsController";
 import GetOrFindMetadataTypesController from "../controller/metadata/getMetadataTypesSettingsController";
 import CopyToClipboardController from "../controller/clipboard/copyToClipboardController";
@@ -49,6 +51,46 @@ const listen = function (worker, apiClientOptions, account) {
     }
     const autofillController = new AutofillController(worker, requestId, apiClientOptions, account);
     await autofillController._exec(resourceId, tab.id);
+  });
+
+  /*
+   * Launch a resource: navigate to its URI then autofill the login form once the page has loaded.
+   * Only dispatched by the popup when the autofillOnLaunch setting is enabled.
+   *
+   * @listens passbolt.quickaccess.launch-resource
+   * @param requestId {uuid} The request identifier
+   * @param resourceId {uuid} The resource identifier
+   * @param openerTabId {number} The id of the tab that was active when the popup opened
+   */
+  worker.port.on("passbolt.quickaccess.launch-resource", async (requestId, resourceId, openerTabId) => {
+    try {
+      const controller = new LaunchResourceController(worker, requestId, apiClientOptions, account);
+      await controller._exec(resourceId, openerTabId);
+    } catch (error) {
+      // _exec handles its own outcome; this guards controller construction so a failure there
+      // cannot become an unhandled rejection.
+      console.error(error);
+      worker.port.emit(requestId, "ERROR", new Error("Unable to launch and autofill the resource."));
+    }
+  });
+
+  /*
+   * Open a resource URI in a tab WITHOUT autofilling (autofill-on-launch disabled). Reuses the
+   * opener tab when it is blank (e.g. an incognito new-tab page) for parity with the autofill path.
+   *
+   * @listens passbolt.quickaccess.open-resource-uri
+   * @param requestId {uuid} The request identifier
+   * @param uri {string} The resource URI to open
+   * @param openerTabId {number} The id of the tab that was active when the popup opened
+   */
+  worker.port.on("passbolt.quickaccess.open-resource-uri", async (requestId, uri, openerTabId) => {
+    try {
+      const controller = new OpenResourceUriInOpenerTabController(worker, requestId);
+      await controller._exec(uri, openerTabId);
+    } catch (error) {
+      console.error(error);
+      worker.port.emit(requestId, "ERROR", new Error("Unable to open the resource URL."));
+    }
   });
 
   /*

--- a/src/all/background_page/index.js
+++ b/src/all/background_page/index.js
@@ -17,6 +17,8 @@ import PostLoginService from "./service/auth/postLoginService";
 import PostLogoutService from "./service/auth/postLogoutService";
 import OnStartUpService from "./service/extension/onStartUpService";
 import ToolbarService from "./service/toolbar/toolbarService";
+// Registers the keyboard-shortcut command listener (e.g. passbolt-lock) on import.
+import "./service/toolbar/keyboardShortcutsService";
 
 const main = async () => {
   /**

--- a/src/all/background_page/pagemod/quickAccessPagemod.js
+++ b/src/all/background_page/pagemod/quickAccessPagemod.js
@@ -16,6 +16,7 @@ import { AuthEvents } from "../event/authEvents";
 import { ConfigEvents } from "../event/configEvents";
 import { KeyringEvents } from "../event/keyringEvents";
 import { QuickAccessEvents } from "../event/quickAccessEvents";
+import { AutofillSettingsEvents } from "../event/autofillSettingsEvents";
 import { GroupEvents } from "../event/groupEvents";
 import { ResourceEvents } from "../event/resourceEvents";
 import { SecretEvents } from "../event/secretEvents";
@@ -47,6 +48,7 @@ class QuickAccess extends Pagemod {
       ConfigEvents,
       KeyringEvents,
       QuickAccessEvents,
+      AutofillSettingsEvents,
       GroupEvents,
       ResourceEvents,
       SecretEvents,

--- a/src/all/background_page/pagemod/quickAccessPagemod.test.js
+++ b/src/all/background_page/pagemod/quickAccessPagemod.test.js
@@ -16,6 +16,7 @@ import { ConfigEvents } from "../event/configEvents";
 import { AuthEvents } from "../event/authEvents";
 import { KeyringEvents } from "../event/keyringEvents";
 import { QuickAccessEvents } from "../event/quickAccessEvents";
+import { AutofillSettingsEvents } from "../event/autofillSettingsEvents";
 import { GroupEvents } from "../event/groupEvents";
 import { ResourceEvents } from "../event/resourceEvents";
 import { SecretEvents } from "../event/secretEvents";
@@ -35,6 +36,7 @@ jest.spyOn(AuthEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(ConfigEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(KeyringEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(QuickAccessEvents, "listen").mockImplementation(jest.fn());
+jest.spyOn(AutofillSettingsEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(GroupEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(ResourceEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(SecretEvents, "listen").mockImplementation(jest.fn());
@@ -55,7 +57,7 @@ describe("QuickAccess", () => {
 
   describe("QuickAccess::attachEvents", () => {
     it("Should attach events", async () => {
-      expect.assertions(17);
+      expect.assertions(18);
       // data mocked
       const port = {
         _port: {
@@ -75,6 +77,7 @@ describe("QuickAccess", () => {
       expect(ConfigEvents.listen).toHaveBeenCalledWith(expectedArgument, apiClientOptions, mockedAccount);
       expect(KeyringEvents.listen).toHaveBeenCalledWith(expectedArgument, apiClientOptions, mockedAccount);
       expect(QuickAccessEvents.listen).toHaveBeenCalledWith(expectedArgument, apiClientOptions, mockedAccount);
+      expect(AutofillSettingsEvents.listen).toHaveBeenCalledWith(expectedArgument, apiClientOptions, mockedAccount);
       expect(GroupEvents.listen).toHaveBeenCalledWith(expectedArgument, apiClientOptions, mockedAccount);
       expect(ResourceEvents.listen).toHaveBeenCalledWith(expectedArgument, apiClientOptions, mockedAccount);
       expect(SecretEvents.listen).toHaveBeenCalledWith(expectedArgument, apiClientOptions, mockedAccount);
@@ -90,6 +93,7 @@ describe("QuickAccess", () => {
         ConfigEvents,
         KeyringEvents,
         QuickAccessEvents,
+        AutofillSettingsEvents,
         GroupEvents,
         ResourceEvents,
         SecretEvents,

--- a/src/all/background_page/service/autofill/autofillSettingsService.js
+++ b/src/all/background_page/service/autofill/autofillSettingsService.js
@@ -1,0 +1,55 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+
+// Must match STORAGE_KEY in webAccessibleResources/options.js (the options page writes this key directly).
+const AUTOFILL_SETTINGS_LOCAL_STORAGE_KEY = "passbolt-autofill-settings";
+
+/**
+ * Service to read and persist the user's "autofill on launch" preference.
+ *
+ * - autofillOnLaunch (default false): when on, clicking the launch action on a quickaccess search
+ *   result navigates to the resource URI and autofills the login form once the page has loaded.
+ *
+ * Note: auto-submit ("auto-login") is intentionally NOT offered. Submitting credentials without a
+ * human seeing the loaded page removes the gating Passbolt deliberately keeps, and was dropped after
+ * security review. The fill is a value the user can inspect and undo.
+ *
+ * This preference is device-local only; it is never sent to the API and never carries any secret.
+ */
+class AutofillSettingsService {
+  /**
+   * Retrieve the autofill settings from the browser local storage.
+   * Unknown or missing values fall back to the safe (off) default.
+   * @return {Promise<{autofillOnLaunch: boolean}>}
+   */
+  static async get() {
+    const storedData = await browser.storage.local.get(AUTOFILL_SETTINGS_LOCAL_STORAGE_KEY);
+    const settings = storedData?.[AUTOFILL_SETTINGS_LOCAL_STORAGE_KEY] || {};
+    return { autofillOnLaunch: settings.autofillOnLaunch === true };
+  }
+
+  /**
+   * Persist the autofill settings in the browser local storage.
+   * The value is normalised to a boolean.
+   * @param {{autofillOnLaunch: boolean}} settings
+   * @return {Promise<{autofillOnLaunch: boolean}>} the persisted settings
+   */
+  static async set(settings) {
+    const normalisedSettings = { autofillOnLaunch: settings?.autofillOnLaunch === true };
+    await browser.storage.local.set({ [AUTOFILL_SETTINGS_LOCAL_STORAGE_KEY]: normalisedSettings });
+    return normalisedSettings;
+  }
+}
+
+export default AutofillSettingsService;

--- a/src/all/background_page/service/autofill/autofillSettingsService.test.js
+++ b/src/all/background_page/service/autofill/autofillSettingsService.test.js
@@ -1,0 +1,50 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+
+import AutofillSettingsService from "./autofillSettingsService";
+
+beforeEach(async () => {
+  await browser.storage.local.clear();
+  jest.clearAllMocks();
+});
+
+describe("AutofillSettingsService", () => {
+  describe("::get", () => {
+    it("returns the safe (off) default when nothing is stored", async () => {
+      expect(await AutofillSettingsService.get()).toEqual({ autofillOnLaunch: false });
+    });
+
+    it("returns autofillOnLaunch true when stored true", async () => {
+      await browser.storage.local.set({ "passbolt-autofill-settings": { autofillOnLaunch: true } });
+      expect(await AutofillSettingsService.get()).toEqual({ autofillOnLaunch: true });
+    });
+
+    it("strictly normalises truthy-but-non-true stored values to false", async () => {
+      await browser.storage.local.set({ "passbolt-autofill-settings": { autofillOnLaunch: "true" } });
+      expect(await AutofillSettingsService.get()).toEqual({ autofillOnLaunch: false });
+    });
+  });
+
+  describe("::set", () => {
+    it("persists and returns a strict boolean", async () => {
+      expect(await AutofillSettingsService.set({ autofillOnLaunch: true })).toEqual({ autofillOnLaunch: true });
+      expect(await AutofillSettingsService.get()).toEqual({ autofillOnLaunch: true });
+    });
+
+    it("coerces non-true input to false", async () => {
+      expect(await AutofillSettingsService.set({ autofillOnLaunch: "yes" })).toEqual({ autofillOnLaunch: false });
+      expect(await AutofillSettingsService.set(undefined)).toEqual({ autofillOnLaunch: false });
+    });
+  });
+});

--- a/src/all/background_page/service/toolbar/keyboardShortcutsService.js
+++ b/src/all/background_page/service/toolbar/keyboardShortcutsService.js
@@ -1,0 +1,71 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+import PassphraseStorageService from "../session_storage/passphraseStorageService";
+import Log from "../../model/log";
+
+/**
+ * Keyboard command identifier for locking the extension.
+ * Declared in each platform manifest under "commands".
+ * @type {string}
+ */
+export const LOCK_COMMAND = "passbolt-lock";
+
+/**
+ * Handles keyboard shortcuts that are not tied to the toolbar icon.
+ *
+ * Registers its own `browser.commands.onCommand` listener. Commands it does not
+ * own are ignored, so it coexists with other command listeners (e.g. the
+ * ToolbarService "passbolt-open" handler) without requiring changes to them.
+ */
+class KeyboardShortcutsService {
+  constructor() {
+    this.handleCommand = this.handleCommand.bind(this);
+    browser.commands.onCommand.addListener(this.handleCommand);
+  }
+
+  /**
+   * Dispatch a keyboard command to its handler.
+   * @param {string} command The command identifier sent by the browser.
+   * @returns {Promise<void>}
+   */
+  async handleCommand(command) {
+    if (command !== LOCK_COMMAND) {
+      // Not handled here; other listeners may handle it.
+      return;
+    }
+    await this.lock();
+  }
+
+  /**
+   * Lock the extension by flushing the cached passphrase from session storage.
+   *
+   * This re-locks the vault without ending the server session: the next
+   * operation that needs the passphrase prompts for it again. It is deliberately
+   * lighter than a full sign-out, which would require re-authentication against
+   * the server. If no passphrase is cached, the flush is a no-op.
+   * @returns {Promise<void>}
+   */
+  async lock() {
+    try {
+      await PassphraseStorageService.flush();
+    } catch (error) {
+      console.error(error);
+      Log.write({ level: "error", message: "KeyboardShortcutsService: failed to lock the extension." });
+    }
+  }
+}
+
+const keyboardShortcutsService = new KeyboardShortcutsService();
+
+export default keyboardShortcutsService;

--- a/src/all/background_page/service/toolbar/keyboardShortcutsService.test.js
+++ b/src/all/background_page/service/toolbar/keyboardShortcutsService.test.js
@@ -1,0 +1,47 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ */
+
+import keyboardShortcutsService, { LOCK_COMMAND } from "./keyboardShortcutsService";
+import PassphraseStorageService from "../session_storage/passphraseStorageService";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("KeyboardShortcutsService", () => {
+  describe("::handleCommand", () => {
+    it("flushes the cached passphrase on the lock command", async () => {
+      const flushMock = jest.spyOn(PassphraseStorageService, "flush").mockResolvedValue(undefined);
+
+      await keyboardShortcutsService.handleCommand(LOCK_COMMAND);
+
+      expect(flushMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores commands it does not own", async () => {
+      const flushMock = jest.spyOn(PassphraseStorageService, "flush").mockResolvedValue(undefined);
+
+      await keyboardShortcutsService.handleCommand("passbolt-open");
+
+      expect(flushMock).not.toHaveBeenCalled();
+    });
+
+    it("does not throw if flushing the passphrase fails", async () => {
+      jest.spyOn(PassphraseStorageService, "flush").mockRejectedValue(new Error("flush failed"));
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(keyboardShortcutsService.handleCommand(LOCK_COMMAND)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/all/options/options.html
+++ b/src/all/options/options.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Passbolt Autofill settings</title>
+  <script src="options.js" defer></script>
+  <style>
+    :root {
+      --bg: #f9f9f9;
+      --card: #ffffff;
+      --border: #e1e1e1;
+      --text: #161514;
+      --muted: #6a6a6a;
+      --accent: #d40101;
+      --accent-on: #2a9d3f;
+      --focus: #5a9bf6;
+    }
+    * { box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      margin: 0; background: var(--bg); color: var(--text);
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrap { max-width: 46rem; margin: 0 auto; padding: 2.4rem 1.6rem; }
+    h1 { font-size: 1.5rem; font-weight: 600; margin: 0 0 .4rem; }
+    .subtitle { color: var(--muted); font-size: .95rem; margin: 0 0 2rem; }
+    .card {
+      background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+      padding: 1.6rem; box-shadow: 0 1px 2px rgba(0,0,0,.04);
+    }
+    .setting { display: flex; align-items: flex-start; justify-content: space-between; gap: 1.2rem; }
+    .setting-text { min-width: 0; }
+    .setting-title { font-weight: 600; font-size: 1.05rem; margin: 0 0 .25rem; }
+    .setting-desc { color: var(--muted); font-size: .9rem; line-height: 1.45; margin: 0; }
+    /* Toggle switch */
+    .switch { position: relative; flex: 0 0 auto; width: 4.4rem; height: 2.4rem; }
+    .switch input { position: absolute; opacity: 0; width: 100%; height: 100%; margin: 0; cursor: pointer; }
+    .slider {
+      position: absolute; inset: 0; background: #cfcfcf; border-radius: 999px;
+      transition: background .15s ease;
+    }
+    .slider::before {
+      content: ""; position: absolute; height: 1.8rem; width: 1.8rem; left: .3rem; top: .3rem;
+      background: #fff; border-radius: 50%; transition: transform .15s ease; box-shadow: 0 1px 2px rgba(0,0,0,.3);
+    }
+    .switch input:checked + .slider { background: var(--accent-on); }
+    .switch input:checked + .slider::before { transform: translateX(2rem); }
+    .switch input:focus-visible + .slider { box-shadow: 0 0 0 .2rem var(--focus); }
+    .note { margin-top: 1.2rem; padding-top: 1.2rem; border-top: 1px solid var(--border); color: var(--muted); font-size: .82rem; line-height: 1.5; }
+    .status { margin-top: 1rem; min-height: 1.2em; color: var(--accent-on); font-size: .9rem; font-weight: 500; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>Autofill</h1>
+    <p class="subtitle">Control how passbolt fills credentials when you launch a resource from the quickaccess.</p>
+
+    <div class="card">
+      <div class="setting">
+        <div class="setting-text">
+          <p class="setting-title">Autofill on launch</p>
+          <p class="setting-desc">
+            When you launch a credential from the quickaccess search results, navigate to its saved
+            website and autofill the login form.
+          </p>
+        </div>
+        <label class="switch">
+          <input type="checkbox" id="autofillOnLaunch" aria-describedby="autofill-note">
+          <span class="slider" aria-hidden="true"></span>
+        </label>
+      </div>
+      <p class="note" id="autofill-note">
+        The form is filled, not submitted, and only when the loaded page's origin matches the saved
+        URL. This setting is stored locally in this browser only; it is never sent to your passbolt
+        server.
+      </p>
+      <p class="status" id="status" role="status" aria-live="polite"></p>
+    </div>
+  </main>
+</body>
+</html>

--- a/src/all/options/options.js
+++ b/src/all/options/options.js
@@ -1,0 +1,55 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.1
+ *
+ * Extension options page for device-local autofill preferences. Reads/writes browser.storage.local
+ * directly (the options page runs in the extension context). Kept dependency-free so it loads as a
+ * plain script under the extension-pages CSP (script-src 'self').
+ */
+(() => {
+  // Must match AUTOFILL_SETTINGS_LOCAL_STORAGE_KEY in background_page/service/autofill/autofillSettingsService.js.
+  const STORAGE_KEY = "passbolt-autofill-settings";
+  const browserApi = globalThis.browser || globalThis.chrome;
+  const checkbox = document.getElementById("autofillOnLaunch");
+  const statusEl = document.getElementById("status");
+
+  function notify(message) {
+    statusEl.textContent = message;
+    if (message) {
+      setTimeout(() => {
+        statusEl.textContent = "";
+      }, 1500);
+    }
+  }
+
+  async function load() {
+    try {
+      const data = await browserApi.storage.local.get(STORAGE_KEY);
+      checkbox.checked = Boolean(data?.[STORAGE_KEY]?.autofillOnLaunch);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  checkbox.addEventListener("change", async () => {
+    try {
+      await browserApi.storage.local.set({ [STORAGE_KEY]: { autofillOnLaunch: checkbox.checked } });
+      notify("Saved.");
+    } catch (error) {
+      console.error(error);
+      checkbox.checked = !checkbox.checked;
+      notify("Could not save the setting.");
+    }
+  });
+
+  load();
+})();

--- a/src/chrome-mv3/index.js
+++ b/src/chrome-mv3/index.js
@@ -19,6 +19,8 @@ import OnExtensionUpdateAvailableService from "../all/background_page/service/ex
 import GlobalAlarmService from "../all/background_page/service/alarm/globalAlarmService";
 import OnStartUpService from "../all/background_page/service/extension/onStartUpService";
 import ToolbarService from "../all/background_page/service/toolbar/toolbarService";
+// Registers the keyboard-shortcut command listener (e.g. passbolt-lock) on import.
+import "../all/background_page/service/toolbar/keyboardShortcutsService";
 import HandleOffscreenResponseService from "./serviceWorker/service/offscreen/handleOffscreenResponseService";
 
 /**

--- a/src/chrome-mv3/manifest.json
+++ b/src/chrome-mv3/manifest.json
@@ -34,7 +34,14 @@
         "mac": "Alt+Shift+P"
       },
       "description": "Open passbolt in a new tab!"
+    },
+    "passbolt-lock": {
+      "description": "Lock passbolt (clear the cached passphrase)"
     }
+  },
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
   },
   "permissions": [
     "activeTab",

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -31,7 +31,14 @@
         "mac": "Alt+Shift+P"
       },
       "description": "Open passbolt in a new tab!"
+    },
+    "passbolt-lock": {
+      "description": "Lock passbolt (clear the cached passphrase)"
     }
+  },
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
   },
   "permissions": [
     "activeTab",

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -40,7 +40,14 @@
         "mac": "Alt+Shift+P"
       },
       "description": "Open passbolt in a new tab!"
+    },
+    "passbolt-lock": {
+      "description": "Lock passbolt (clear the cached passphrase)"
     }
+  },
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
   },
   "permissions": [
     "activeTab",

--- a/src/safari/background_page/index.js
+++ b/src/safari/background_page/index.js
@@ -22,6 +22,8 @@ import PostLoginService from "../../all/background_page/service/auth/postLoginSe
 import PostLogoutService from "../../all/background_page/service/auth/postLogoutService";
 import OnStartUpService from "../../all/background_page/service/extension/onStartUpService";
 import ToolbarService from "../../all/background_page/service/toolbar/toolbarService";
+// Registers the keyboard-shortcut command listener (e.g. passbolt-lock) on import.
+import "../../all/background_page/service/toolbar/keyboardShortcutsService";
 import WebNavigationService from "../../all/background_page/service/webNavigation/webNavigationService";
 
 const main = async () => {

--- a/src/safari/manifest.json
+++ b/src/safari/manifest.json
@@ -25,7 +25,14 @@
         "mac": "Alt+Shift+P"
       },
       "description": "Open passbolt in a new tab!"
+    },
+    "passbolt-lock": {
+      "description": "Lock passbolt (clear the cached passphrase)"
     }
+  },
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
   },
   "permissions": [
     "activeTab",


### PR DESCRIPTION
## Summary

Three small, **opt-in / additive** quality-of-life capabilities for the extension. Existing autofill UX is unchanged; nothing here is enabled by default beyond a neutral keyboard command.

1. **Lock-extension keyboard shortcut** — a new `passbolt-lock` command that flushes the cached passphrase (re-locks the vault without ending the server session; lighter than a full sign-out).
2. **Autofill on launch (opt-in, off by default)** — when enabled via a new device-local setting, launching a credential from the quickaccess search results navigates to its saved URL and autofills the login form. The form is **filled, never submitted**. Toggled from a new options page (`options_ui`).
3. **Open-without-autofill tab reuse** — when the setting is off, launching simply opens the URL, reusing a blank/new-tab page instead of always opening a new tab.

The matching popup UI is a companion `passbolt_styleguide` PR.

## Security model (autofill path)

- **No auto-submit** — the credential is filled and left for the user to inspect; never submitted.
- **https-only** target, with **trusted-side origin binding**: before decrypting or filling, the loaded page's browser-verified origin is matched against the resource's stored URL, and **re-checked immediately before the fill is dispatched** (TOCTOU guard, since the passphrase prompt can be slow). Refuses on mismatch.
- Caller input is validated; errors surfaced to the popup are sanitised; the preference is a single boolean in `storage.local` (never synced, carries no secret); the options page is served via `options_ui` and is **not** web-accessible.

## Tests

Unit tests cover the launch controller (origin-mismatch refusal, disabled guard, https rejection, happy-path fill + TOCTOU re-check, tab reuse vs new-tab, input validation, error sanitisation), the settings service/event, the lock command, and the open-without-autofill path. Manually verified in Chromium (MV3) and Firefox, autofill on and off.

## Notes

Opt-in and additive. Opened as a **draft** for maintainer feedback on scope and approach. Companion UI PR: `passbolt/passbolt_styleguide` (linked once both are open).
