### PR TITLE
PB-27841: store a per-user in-form integration preference (back-end)

### DIFF
--- a/src/all/background_page/event/inFormIntegrationSettingsEvents.js
+++ b/src/all/background_page/event/inFormIntegrationSettingsEvents.js
@@ -1,0 +1,69 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.7.0
+ */
+import GetActiveAccountService from "../service/account/getActiveAccountService";
+import InFormIntegrationSettingsLocalStorage from "../service/local_storage/inFormIntegrationSettingsLocalStorage";
+import InFormIntegrationSettingsEntity from "../model/entity/inFormIntegration/inFormIntegrationSettingsEntity";
+
+/**
+ * Listens to the in-form integration settings events.
+ *
+ * These events are registered on both the application pagemod (so the settings screen can read and
+ * update the preference) and the web integration pagemod (so the content script bootstrap can read
+ * it). The account is resolved internally so the handlers behave the same in both contexts.
+ *
+ * @param {Worker} worker
+ * @param {ApiClientOptions} [_apiClientOptions]
+ * @param {AbstractAccountEntity} [account] The account, only provided on the application pagemod.
+ */
+const listen = function (worker, _apiClientOptions, account) {
+  /*
+   * Get the user's in-form integration settings.
+   *
+   * @listens passbolt.in-form-integration-settings.get
+   * @param requestId {uuid} The request identifier
+   */
+  worker.port.on("passbolt.in-form-integration-settings.get", async (requestId) => {
+    try {
+      const resolvedAccount = account || (await GetActiveAccountService.get());
+      const localStorage = new InFormIntegrationSettingsLocalStorage(resolvedAccount);
+      const settings = (await localStorage.get()) || InFormIntegrationSettingsEntity.createDefault();
+      worker.port.emit(requestId, "SUCCESS", settings.toDto());
+    } catch (error) {
+      console.error(error);
+      worker.port.emit(requestId, "ERROR", error);
+    }
+  });
+
+  /*
+   * Set the user's in-form integration settings.
+   *
+   * @listens passbolt.in-form-integration-settings.set
+   * @param requestId {uuid} The request identifier
+   * @param settingsDto {object} The settings to save
+   */
+  worker.port.on("passbolt.in-form-integration-settings.set", async (requestId, settingsDto) => {
+    try {
+      const resolvedAccount = account || (await GetActiveAccountService.get());
+      const localStorage = new InFormIntegrationSettingsLocalStorage(resolvedAccount);
+      const settings = new InFormIntegrationSettingsEntity(settingsDto);
+      await localStorage.set(settings);
+      worker.port.emit(requestId, "SUCCESS", settings.toDto());
+    } catch (error) {
+      console.error(error);
+      worker.port.emit(requestId, "ERROR", error);
+    }
+  });
+};
+
+export const InFormIntegrationSettingsEvents = { listen };

--- a/src/all/background_page/model/entity/inFormIntegration/inFormIntegrationSettingsEntity.js
+++ b/src/all/background_page/model/entity/inFormIntegration/inFormIntegrationSettingsEntity.js
@@ -1,0 +1,93 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.7.0
+ */
+import Entity from "passbolt-styleguide/src/shared/models/entity/abstract/entity";
+import EntitySchema from "passbolt-styleguide/src/shared/models/entity/abstract/entitySchema";
+
+const ENTITY_NAME = "InFormIntegrationSettings";
+
+/**
+ * Client-side, per-user preferences for the in-form integration (call-to-action icon, in-form menu
+ * and auto-save). These preferences are stored locally in the extension and let a user opt out of
+ * the in-form menu without the server administrator disabling it for the whole organization.
+ */
+class InFormIntegrationSettingsEntity extends Entity {
+  /**
+   * @inheritDoc
+   */
+  constructor(inFormIntegrationSettings, options = {}) {
+    super(
+      EntitySchema.validate(
+        InFormIntegrationSettingsEntity.ENTITY_NAME,
+        inFormIntegrationSettings,
+        InFormIntegrationSettingsEntity.getSchema(),
+      ),
+      options,
+    );
+  }
+
+  /**
+   * Get the entity schema
+   * @returns {object}
+   */
+  static getSchema() {
+    return {
+      type: "object",
+      required: ["isInFormMenuEnabled"],
+      properties: {
+        isInFormMenuEnabled: {
+          type: "boolean",
+        },
+      },
+    };
+  }
+
+  /**
+   * Build a default settings entity, with the in-form menu enabled.
+   * @returns {InFormIntegrationSettingsEntity}
+   */
+  static createDefault() {
+    return new InFormIntegrationSettingsEntity({ isInFormMenuEnabled: true });
+  }
+
+  /**
+   * Return props
+   * @returns {any}
+   */
+  get props() {
+    return this._props;
+  }
+
+  /**
+   * Whether the in-form menu (call-to-action icon, in-form menu and auto-save) is enabled.
+   * @returns {boolean}
+   */
+  get isInFormMenuEnabled() {
+    return this._props.isInFormMenuEnabled;
+  }
+
+  /*
+   * ==================================================
+   * Static properties getters
+   * ==================================================
+   */
+  /**
+   * InFormIntegrationSettingsEntity.ENTITY_NAME
+   * @returns {string}
+   */
+  static get ENTITY_NAME() {
+    return ENTITY_NAME;
+  }
+}
+
+export default InFormIntegrationSettingsEntity;

--- a/src/all/background_page/model/entity/inFormIntegration/inFormIntegrationSettingsEntity.test.js
+++ b/src/all/background_page/model/entity/inFormIntegration/inFormIntegrationSettingsEntity.test.js
@@ -1,0 +1,51 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.7.0
+ */
+import InFormIntegrationSettingsEntity from "./inFormIntegrationSettingsEntity";
+import EntitySchema from "passbolt-styleguide/src/shared/models/entity/abstract/entitySchema";
+
+describe("InFormIntegrationSettingsEntity", () => {
+  describe("InFormIntegrationSettingsEntity::getSchema", () => {
+    it("schema must validate", () => {
+      EntitySchema.validateSchema(
+        InFormIntegrationSettingsEntity.ENTITY_NAME,
+        InFormIntegrationSettingsEntity.getSchema(),
+      );
+    });
+  });
+
+  describe("InFormIntegrationSettingsEntity::constructor", () => {
+    it("should accept a valid dto", () => {
+      expect.assertions(1);
+      const entity = new InFormIntegrationSettingsEntity({ isInFormMenuEnabled: false });
+      expect(entity.isInFormMenuEnabled).toBe(false);
+    });
+
+    it("should throw if isInFormMenuEnabled is missing", () => {
+      expect.assertions(1);
+      expect(() => new InFormIntegrationSettingsEntity({})).toThrow();
+    });
+
+    it("should throw if isInFormMenuEnabled is not a boolean", () => {
+      expect.assertions(1);
+      expect(() => new InFormIntegrationSettingsEntity({ isInFormMenuEnabled: "yes" })).toThrow();
+    });
+  });
+
+  describe("InFormIntegrationSettingsEntity::createDefault", () => {
+    it("should default to the in-form menu being enabled", () => {
+      expect.assertions(1);
+      expect(InFormIntegrationSettingsEntity.createDefault().isInFormMenuEnabled).toBe(true);
+    });
+  });
+});

--- a/src/all/background_page/pagemod/appPagemod.js
+++ b/src/all/background_page/pagemod/appPagemod.js
@@ -43,6 +43,7 @@ import GetActiveAccountService from "../service/account/getActiveAccountService"
 import { PermissionEvents } from "../event/permissionEvents";
 import { AccountEvents } from "../event/accountEvents";
 import { AppSignOutEvents } from "../event/appSignOutEvents";
+import { InFormIntegrationSettingsEvents } from "../event/inFormIntegrationSettingsEvents";
 
 class App extends Pagemod {
   /**
@@ -84,6 +85,7 @@ class App extends Pagemod {
       RememberMeEvents,
       PermissionEvents,
       AccountEvents,
+      InFormIntegrationSettingsEvents,
     ];
   }
 

--- a/src/all/background_page/pagemod/appPagemod.test.js
+++ b/src/all/background_page/pagemod/appPagemod.test.js
@@ -45,6 +45,7 @@ import GetActiveAccountService from "../service/account/getActiveAccountService"
 import { PermissionEvents } from "../event/permissionEvents";
 import { AccountEvents } from "../event/accountEvents";
 import { AppSignOutEvents } from "../event/appSignOutEvents";
+import { InFormIntegrationSettingsEvents } from "../event/inFormIntegrationSettingsEvents";
 
 jest.spyOn(ConfigEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(AppEvents, "listen").mockImplementation(jest.fn());
@@ -73,6 +74,7 @@ jest.spyOn(RememberMeEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(PermissionEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(AccountEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(AppSignOutEvents, "listen").mockImplementation(jest.fn());
+jest.spyOn(InFormIntegrationSettingsEvents, "listen").mockImplementation(jest.fn());
 
 describe("App", () => {
   beforeEach(() => {
@@ -83,7 +85,7 @@ describe("App", () => {
 
   describe("App::attachEvents", () => {
     it("Should attach app events", async () => {
-      expect.assertions(30);
+      expect.assertions(31);
       // data mocked
       const port = {
         _port: {
@@ -137,6 +139,11 @@ describe("App", () => {
       expect(RememberMeEvents.listen).toHaveBeenCalledWith(expectedPortAndTab, mockApiClient, mockedAccount);
       expect(PermissionEvents.listen).toHaveBeenCalledWith(expectedPortAndTab, mockApiClient, mockedAccount);
       expect(AccountEvents.listen).toHaveBeenCalledWith(expectedPortAndTab, mockApiClient, mockedAccount);
+      expect(InFormIntegrationSettingsEvents.listen).toHaveBeenCalledWith(
+        expectedPortAndTab,
+        mockApiClient,
+        mockedAccount,
+      );
       expect(App.events).toStrictEqual([
         ConfigEvents,
         AppEvents,
@@ -164,6 +171,7 @@ describe("App", () => {
         RememberMeEvents,
         PermissionEvents,
         AccountEvents,
+        InFormIntegrationSettingsEvents,
       ]);
       expect(App.mustReloadOnExtensionUpdate).toBeFalsy();
       expect(App.appName).toBe("App");

--- a/src/all/background_page/pagemod/webIntegrationPagemod.js
+++ b/src/all/background_page/pagemod/webIntegrationPagemod.js
@@ -15,6 +15,7 @@ import Pagemod from "./pagemod";
 import { ConfigEvents } from "../event/configEvents";
 import { WebIntegrationEvents } from "../event/webIntegrationEvents";
 import { OrganizationSettingsEvents } from "../event/organizationSettingsEvents";
+import { InFormIntegrationSettingsEvents } from "../event/inFormIntegrationSettingsEvents";
 import { PortEvents } from "../event/portEvents";
 import ParseWebIntegrationUrlService from "../service/webIntegration/parseWebIntegrationUrlService";
 import GetActiveAccountService from "../service/account/getActiveAccountService";
@@ -49,7 +50,13 @@ class WebIntegration extends Pagemod {
    * @inheritDoc
    */
   get events() {
-    return [ConfigEvents, WebIntegrationEvents, OrganizationSettingsEvents, PortEvents];
+    return [
+      ConfigEvents,
+      WebIntegrationEvents,
+      OrganizationSettingsEvents,
+      InFormIntegrationSettingsEvents,
+      PortEvents,
+    ];
   }
 
   /**

--- a/src/all/background_page/pagemod/webIntegrationPagemod.test.js
+++ b/src/all/background_page/pagemod/webIntegrationPagemod.test.js
@@ -21,6 +21,7 @@ import Pagemod from "./pagemod";
 import { ConfigEvents } from "../event/configEvents";
 import { OrganizationSettingsEvents } from "../event/organizationSettingsEvents";
 import { WebIntegrationEvents } from "../event/webIntegrationEvents";
+import { InFormIntegrationSettingsEvents } from "../event/inFormIntegrationSettingsEvents";
 import { PortEvents } from "../event/portEvents";
 
 const spyAddWorker = jest.spyOn(WorkersSessionStorage, "addWorker");
@@ -30,6 +31,7 @@ jest.spyOn(ScriptExecution.prototype, "injectJs").mockImplementation(jest.fn());
 jest.spyOn(ConfigEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(WebIntegrationEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(OrganizationSettingsEvents, "listen").mockImplementation(jest.fn());
+jest.spyOn(InFormIntegrationSettingsEvents, "listen").mockImplementation(jest.fn());
 jest.spyOn(PortEvents, "listen").mockImplementation(jest.fn());
 
 describe("WebIntegration", () => {
@@ -58,6 +60,7 @@ describe("WebIntegration", () => {
         ConfigEvents,
         WebIntegrationEvents,
         OrganizationSettingsEvents,
+        InFormIntegrationSettingsEvents,
         PortEvents,
       ]);
       expect(WebIntegration.mustReloadOnExtensionUpdate).toBeFalsy();
@@ -102,7 +105,7 @@ describe("WebIntegration", () => {
 
   describe("WebIntegration::attachEvents", () => {
     it("Should attach events", async () => {
-      expect.assertions(4);
+      expect.assertions(5);
       // data mocked
       const port = {
         on: () => jest.fn(),
@@ -128,6 +131,11 @@ describe("WebIntegration", () => {
         name: WebIntegration.appName,
       });
       expect(OrganizationSettingsEvents.listen).toHaveBeenCalledWith({
+        port: port,
+        tab: port._port.sender.tab,
+        name: WebIntegration.appName,
+      });
+      expect(InFormIntegrationSettingsEvents.listen).toHaveBeenCalledWith({
         port: port,
         tab: port._port.sender.tab,
         name: WebIntegration.appName,

--- a/src/all/background_page/service/local_storage/inFormIntegrationSettingsLocalStorage.js
+++ b/src/all/background_page/service/local_storage/inFormIntegrationSettingsLocalStorage.js
@@ -1,0 +1,84 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.7.0
+ */
+import Log from "../../model/log";
+import InFormIntegrationSettingsEntity from "../../model/entity/inFormIntegration/inFormIntegrationSettingsEntity";
+
+export const IN_FORM_INTEGRATION_SETTINGS_LOCAL_STORAGE_KEY = "inFormIntegrationSettings";
+
+/**
+ * Local (per-account) storage for the user's in-form integration preferences.
+ */
+class InFormIntegrationSettingsLocalStorage {
+  /**
+   * Constructor
+   * @param {AbstractAccountEntity} account the user account
+   */
+  constructor(account) {
+    this.storageKey = this.getStorageKey(account);
+  }
+
+  /**
+   * Get the storage key.
+   * @param {AbstractAccountEntity} account The account to get the key for.
+   * @returns {string}
+   * @throws {Error} If it cannot retrieve account id.
+   */
+  getStorageKey(account) {
+    if (!account.id) {
+      throw new Error("Cannot retrieve account id, necessary to get an inFormIntegrationSettings storage key.");
+    }
+    return `${IN_FORM_INTEGRATION_SETTINGS_LOCAL_STORAGE_KEY}-${account.id}`;
+  }
+
+  /**
+   * Flush the inFormIntegrationSettings local storage
+   * @return {Promise<void>}
+   */
+  async flush() {
+    Log.write({ level: "debug", message: "InFormIntegrationSettingsLocalStorage flushed" });
+    await browser.storage.local.remove(this.storageKey);
+  }
+
+  /**
+   * Get the InFormIntegrationSettings local storage.
+   * @return {Promise<InFormIntegrationSettingsEntity|null>} the settings entity or null when nothing valid is stored.
+   */
+  async get() {
+    const value = await browser.storage.local.get([this.storageKey]);
+    if (!value || !value[this.storageKey]) {
+      return null;
+    }
+
+    // ensure this feature is not breaking anything by returning an accepted default value
+    try {
+      return new InFormIntegrationSettingsEntity(value[this.storageKey]);
+    } catch (e) {
+      console.error(e);
+      return null;
+    }
+  }
+
+  /**
+   * Set the inFormIntegrationSettings in local storage.
+   * @param {InFormIntegrationSettingsEntity} inFormIntegrationSettingsEntity the value to save.
+   * @return {Promise<void>}
+   */
+  async set(inFormIntegrationSettingsEntity) {
+    await navigator.locks.request(this.storageKey, async () => {
+      await browser.storage.local.set({ [this.storageKey]: inFormIntegrationSettingsEntity.toDto() });
+    });
+  }
+}
+
+export default InFormIntegrationSettingsLocalStorage;

--- a/src/all/background_page/service/local_storage/inFormIntegrationSettingsLocalStorage.test.js
+++ b/src/all/background_page/service/local_storage/inFormIntegrationSettingsLocalStorage.test.js
@@ -1,0 +1,86 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2024 Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.7.0
+ */
+import AccountEntity from "../../model/entity/account/accountEntity";
+import { defaultAccountDto } from "../../model/entity/account/accountEntity.test.data";
+import InFormIntegrationSettingsLocalStorage from "./inFormIntegrationSettingsLocalStorage";
+import InFormIntegrationSettingsEntity from "../../model/entity/inFormIntegration/inFormIntegrationSettingsEntity";
+
+describe("InFormIntegrationSettingsLocalStorage", () => {
+  const account = new AccountEntity(defaultAccountDto());
+
+  beforeEach(async () => {
+    await browser.storage.local.clear();
+  });
+
+  describe("InFormIntegrationSettingsLocalStorage::constructor", () => {
+    it("Should throw if the account has no id", () => {
+      expect.assertions(1);
+      expect(() => new InFormIntegrationSettingsLocalStorage({})).toThrow();
+    });
+
+    it("Should build a per-account storage key", () => {
+      expect.assertions(1);
+      const storage = new InFormIntegrationSettingsLocalStorage(account);
+      expect(storage.storageKey).toStrictEqual(`inFormIntegrationSettings-${account.id}`);
+    });
+  });
+
+  describe("InFormIntegrationSettingsLocalStorage::get", () => {
+    it("Should return null if nothing is stored", async () => {
+      expect.assertions(1);
+      const storage = new InFormIntegrationSettingsLocalStorage(account);
+      expect(await storage.get()).toBeNull();
+    });
+
+    it("Should return the entity stored in the local storage", async () => {
+      expect.assertions(1);
+      const storage = new InFormIntegrationSettingsLocalStorage(account);
+      const entity = new InFormIntegrationSettingsEntity({ isInFormMenuEnabled: false });
+      await browser.storage.local.set({ [storage.storageKey]: entity.toDto() });
+      expect(await storage.get()).toEqual(entity);
+    });
+
+    it("Should return null if the stored value cannot be validated", async () => {
+      expect.assertions(1);
+      const storage = new InFormIntegrationSettingsLocalStorage(account);
+      await browser.storage.local.set({ [storage.storageKey]: { isInFormMenuEnabled: "not-a-boolean" } });
+      expect(await storage.get()).toBeNull();
+    });
+  });
+
+  describe("InFormIntegrationSettingsLocalStorage::set", () => {
+    it("Should persist the settings in the local storage", async () => {
+      expect.assertions(2);
+      const storage = new InFormIntegrationSettingsLocalStorage(account);
+
+      const disabled = new InFormIntegrationSettingsEntity({ isInFormMenuEnabled: false });
+      await storage.set(disabled);
+      expect(await storage.get()).toEqual(disabled);
+
+      const enabled = new InFormIntegrationSettingsEntity({ isInFormMenuEnabled: true });
+      await storage.set(enabled);
+      expect(await storage.get()).toEqual(enabled);
+    });
+  });
+
+  describe("InFormIntegrationSettingsLocalStorage::flush", () => {
+    it("Should remove the settings from the local storage", async () => {
+      expect.assertions(1);
+      const storage = new InFormIntegrationSettingsLocalStorage(account);
+      await storage.set(InFormIntegrationSettingsEntity.createDefault());
+      await storage.flush();
+      expect(await storage.get()).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## PB-27841: store a per-user in-form integration preference (back-end)

This pull request is a (multiple allowed):

* [ ] bug fix
* [ ] change of existing behavior
* [x] new feature

Checklist
* [x] User stories are present (given, when, then format)
* [x] Unit tests are passing
* [ ] Selenium tests are passing
* [x] Check style is not triggering new error or warning

### What you did

Resolves the back-end half of **[PB-27841 — "As a user I should be able to disable the in-form menu in the settings"](https://community.passbolt.com/t/pb-27841-as-a-user-i-should-be-able-to-disable-the-in-form-menu-in-the-settings/4752)**.

**Problem.** Today the in-form integration (call-to-action icon, in-form menu and auto-save) can only be turned off **org-wide** by a server administrator via `PASSBOLT_PLUGINS_IN_FORM_INTEGRATION_ENABLED=false` (`SiteSettings.canIUse("inFormIntegration")`). There is no per-user switch. The community thread has asked for a client-side, user-level toggle since 2022, and a maintainer agreed it *should* exist:

> *"I agree there should be a user setting to control this, unfortunately this is not the case at the moment."* — @remy, Jan 2022

> *"on most OTP forms I now have 6 Passbolt icons obscuring the one digit wide field… A way to be able to only use the Passbolt Web UI and not have any of the auto-fill, suggestions, icons or other stuff would be much appreciated."* — Apr 2026

This is consistent with how other password managers expose the choice **per user** (1Password, Bitwarden, LastPass, Dashlane all let the user disable in-page integration from the extension UI).

**What this PR adds (back-end / messaging only):**

- **`InFormIntegrationSettingsEntity`** — a schema-validated `{ isInFormMenuEnabled: boolean }` setting, defaulting to enabled.
- **`InFormIntegrationSettingsLocalStorage`** — per-account `browser.storage.local` persistence, mirroring `UserRememberMeLatestChoiceLocalStorage`.
- **`InFormIntegrationSettingsEvents`** — `passbolt.in-form-integration-settings.get` / `.set` port handlers. The account is resolved internally (`GetActiveAccountService`) so the handlers behave identically whether they are reached from the **application** pagemod (settings screen reads/writes) or the **web integration** pagemod (content-script bootstrap reads).
- Registered the events on **`appPagemod`** and **`webIntegrationPagemod`**, and updated their unit tests.

#### User stories

- **Given** I am a logged-in user, **when** I disable the in-form menu in my settings, **then** the choice is persisted locally for my account and survives a browser restart.
- **Given** I have not changed anything, **when** the extension reads the preference, **then** it reports the in-form menu as enabled (no behaviour change).

#### Tests

- `inFormIntegrationSettingsEntity.test.js` (schema validation, default, invalid input).
- `inFormIntegrationSettingsLocalStorage.test.js` (per-account key, get/set/flush, invalid-value handling).
- Updated `appPagemod.test.js` / `webIntegrationPagemod.test.js` for the new event registration.
- `eslint --max-warnings 0` clean on changed files.

#### Companion PR

The user-facing settings screen and the bootstrap gate that consume these handlers are in **passbolt/passbolt_styleguide → passbolt/passbolt_styleguide#58**. This PR is the storage/messaging foundation; on its own it changes no behaviour until the styleguide side calls the new port messages.
