### PR TITLE
Fix #271 allow blob URLs in extension img-src CSP

### DIFF
--- a/src/all/manifest.test.js
+++ b/src/all/manifest.test.js
@@ -1,0 +1,62 @@
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         5.12.2
+ */
+
+import fs from "fs";
+import path from "path";
+
+const manifestFixtures = [
+  {
+    label: "chrome manifest",
+    manifestPath: "src/chrome/manifest.json",
+    getCsp: (manifest) => manifest.content_security_policy,
+  },
+  {
+    label: "chrome mv3 manifest",
+    manifestPath: "src/chrome-mv3/manifest.json",
+    getCsp: (manifest) => manifest.content_security_policy.extension_pages,
+  },
+  {
+    label: "firefox manifest",
+    manifestPath: "src/firefox/manifest.json",
+    getCsp: (manifest) => manifest.content_security_policy,
+  },
+  {
+    label: "safari manifest",
+    manifestPath: "src/safari/manifest.json",
+    getCsp: (manifest) => manifest.content_security_policy,
+  },
+];
+
+const readManifest = (manifestPath) => {
+  const absolutePath = path.join(process.cwd(), manifestPath);
+  return JSON.parse(fs.readFileSync(absolutePath, "utf8"));
+};
+
+const getDirectiveValue = (csp, directiveName) =>
+  csp
+    .split(";")
+    .map((directive) => directive.trim())
+    .find((directive) => directive.startsWith(`${directiveName} `));
+
+describe("Extension manifests", () => {
+  it.each(manifestFixtures)("keeps blob: enabled in img-src for $label", ({ manifestPath, getCsp }) => {
+    expect.assertions(1);
+
+    const manifest = readManifest(manifestPath);
+    const csp = getCsp(manifest);
+    const imgSrcDirective = getDirectiveValue(csp, "img-src");
+
+    expect(imgSrcDirective).toContain("blob:");
+  });
+});

--- a/src/chrome-mv3/manifest.json
+++ b/src/chrome-mv3/manifest.json
@@ -57,6 +57,6 @@
     "matches": ["*://*/*"]
   }],
   "content_security_policy": {
-    "extension_pages": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http: ; font-src 'self'; connect-src 'self' https: http: ; form-action 'self' https: ; frame-src 'self' ; frame-ancestors 'self' https: http: ; worker-src 'self' ; base-uri 'none' ;"
+    "extension_pages": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http: ; font-src 'self'; connect-src 'self' https: http: ; form-action 'self' https: ; frame-src 'self' ; frame-ancestors 'self' https: http: ; worker-src 'self' ; base-uri 'none' ;"
   }
 }

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -48,5 +48,5 @@
   "web_accessible_resources": [
     "webAccessibleResources/*"
   ],
-  "content_security_policy": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http: ; font-src 'self'; connect-src 'self' https: http: ; form-action 'self' https: ; frame-src 'self' ; frame-ancestors 'self' https: http: ; worker-src 'self' ; base-uri 'none' ;"
+  "content_security_policy": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http: ; font-src 'self'; connect-src 'self' https: http: ; form-action 'self' https: ; frame-src 'self' ; frame-ancestors 'self' https: http: ; worker-src 'self' ; base-uri 'none' ;"
 }

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -55,5 +55,5 @@
   "web_accessible_resources": [
     "webAccessibleResources/*"
   ],
-  "content_security_policy": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http: ; font-src 'self'; connect-src 'self' https: http: ; form-action 'self' https: ; frame-src 'self' ; frame-ancestors 'self' https: http: ; worker-src 'self' ; base-uri 'none' ;"
+  "content_security_policy": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http: ; font-src 'self'; connect-src 'self' https: http: ; form-action 'self' https: ; frame-src 'self' ; frame-ancestors 'self' https: http: ; worker-src 'self' ; base-uri 'none' ;"
 }

--- a/src/safari/manifest.json
+++ b/src/safari/manifest.json
@@ -43,5 +43,5 @@
   "web_accessible_resources": [
     "webAccessibleResources/*"
   ],
-  "content_security_policy": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http: ; font-src 'self'; connect-src 'self' https: http: ; form-action 'self' https: ; frame-src 'self' ; frame-ancestors 'self' https: http: ; worker-src 'self' ; base-uri 'none' ;"
+  "content_security_policy": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http: ; font-src 'self'; connect-src 'self' https: http: ; form-action 'self' https: ; frame-src 'self' ; frame-ancestors 'self' https: http: ; worker-src 'self' ; base-uri 'none' ;"
 }


### PR DESCRIPTION
This PR fixes issue #271 by allowing `blob:` image URLs in the browser extension CSP.

The issue comes from the extension manifests: `img-src` allowed `'self'`, `data:`, `https:`, and `http:`, but not `blob:`. QR/image handling flows can rely on blob-backed image URLs, so the browser could block those resources inside the extension context.

## Root cause

This was a CSP configuration issue rather than a TOTP business-logic issue.

The affected manifests did not include `blob:` in `img-src`:
- `src/chrome/manifest.json`
- `src/chrome-mv3/manifest.json`
- `src/firefox/manifest.json`
- `src/safari/manifest.json`

Because of that, blob-backed images used during QR-related flows could fail to load.

## Changes

- Added `blob:` to `img-src` in all supported browser manifests
- Added a regression test in `src/all/manifest.test.js` to verify every manifest keeps `blob:` enabled in `img-src`

## Why this approach

I kept the change intentionally narrow:
- only the `img-src` directive was updated
- no changes were made to `script-src`
- no runtime logic or permissions were changed
- all browser targets remain aligned

This fixes the issue at the correct layer with minimal risk.

## Verification

Automated:
- `npx.cmd jest --no-cache src/all/manifest.test.js`
- `npx.cmd eslint src/all/manifest.test.js`

Both passed locally.

Runtime:
- loaded the extension in Chrome from `build/all`
- verified that a blob-backed image can load successfully inside the extension context without CSP errors

## Notes

The quickaccess `Create password` popup does not expose the TOTP QR upload path, so I could not validate the end-to-end QR upload flow from that screen.

However, the fix itself was validated at the correct technical layer:
- manifest-level CSP updated
- regression test added
- runtime blob image loading confirmed in the extension