### PR TITLE
Add basic auth support

### DIFF
--- a/src/all/background_page/index.js
+++ b/src/all/background_page/index.js
@@ -17,6 +17,8 @@ import PostLoginService from "./service/auth/postLoginService";
 import PostLogoutService from "./service/auth/postLogoutService";
 import OnStartUpService from "./service/extension/onStartUpService";
 import ToolbarService from "./service/toolbar/toolbarService";
+import BasicAuthService from "./service/auth/basicAuthService";
+import BrowserService from "./service/browser/browserService";
 
 const main = async () => {
   /**
@@ -113,3 +115,13 @@ browser.tabs.onActivated.addListener(ToolbarService.handleSuggestedResourcesOnAc
  * Handle suggested resources on toolbar icon
  */
 browser.windows.onFocusChanged.addListener(ToolbarService.handleSuggestedResourcesOnFocusedWindow);
+
+if (BrowserService.isFirefox()) {
+  browser.webRequest.onAuthRequired.addListener(
+    (details) => BasicAuthService.handle(details),
+    { urls: ["<all_urls>"] },
+    ["blocking"],
+  );
+  browser.webRequest.onCompleted.addListener((details) => BasicAuthService.clear(details), { urls: ["<all_urls>"] });
+  browser.webRequest.onErrorOccurred.addListener((details) => BasicAuthService.clear(details), { urls: ["<all_urls>"] });
+}

--- a/src/all/background_page/service/auth/basicAuthService.js
+++ b/src/all/background_page/service/auth/basicAuthService.js
@@ -1,0 +1,51 @@
+import GetActiveAccountService from "../account/getActiveAccountService";
+import BuildApiClientOptionsService from "../account/buildApiClientOptionsService";
+import GetOrFindResourcesService from "../resource/getOrFindResourcesService";
+import GetPassphraseService from "../passphrase/getPassphraseService";
+import FindSecretService from "../secret/findSecretService";
+import ResourceTypeModel from "../../model/resourceType/resourceTypeModel";
+import GetDecryptedUserPrivateKeyService from "../account/getDecryptedUserPrivateKeyService";
+import DecryptAndParseResourceSecretService from "../secret/decryptAndParseResourceSecretService";
+
+class BasicAuthService {
+  constructor() {
+    this.pendingRequestIds = new Set();
+  }
+
+  async handle(details) {
+    if (this.pendingRequestIds.has(details.requestId) || details.tabId < 0) {
+      return {};
+    }
+    this.pendingRequestIds.add(details.requestId);
+    try {
+      const account = await GetActiveAccountService.get();
+      const apiClientOptions = BuildApiClientOptionsService.buildFromAccount(account);
+      const markerUrl = `${details.url.match(/^[^:/?#]+:\/\/[^/?#]+/)[0]}/.htpasswd`;
+      const resources = await new GetOrFindResourcesService(account, apiClientOptions).getOrFindSuggested(
+        markerUrl,
+        "password",
+      );
+      const resource = resources.items.find((item) => item.metadata?.uris?.includes(markerUrl));
+      if (!resource) {
+        return {};
+      }
+      const passphrase = await new GetPassphraseService(account).requestPassphraseFromQuickAccess();
+      const secret = await new FindSecretService(account, apiClientOptions).findByResourceId(resource.id);
+      const schema = await new ResourceTypeModel(apiClientOptions).getSecretSchemaById(resource.resourceTypeId);
+      const privateKey = await GetDecryptedUserPrivateKeyService.getKey(passphrase);
+      const plaintext = await DecryptAndParseResourceSecretService.decryptAndParse(secret, schema, privateKey);
+      if (typeof plaintext.password !== "string") {
+        return {};
+      }
+      return { authCredentials: { username: resource.metadata?.username || "", password: plaintext.password } };
+    } catch {
+      return {};
+    }
+  }
+
+  clear(details) {
+    this.pendingRequestIds.delete(details.requestId);
+  }
+}
+
+export default new BasicAuthService();

--- a/src/chrome-mv3/index.js
+++ b/src/chrome-mv3/index.js
@@ -20,6 +20,7 @@ import GlobalAlarmService from "../all/background_page/service/alarm/globalAlarm
 import OnStartUpService from "../all/background_page/service/extension/onStartUpService";
 import ToolbarService from "../all/background_page/service/toolbar/toolbarService";
 import HandleOffscreenResponseService from "./serviceWorker/service/offscreen/handleOffscreenResponseService";
+import BasicAuthService from "../all/background_page/service/auth/basicAuthService";
 
 /**
  * Load all system requirement
@@ -85,3 +86,11 @@ browser.tabs.onActivated.addListener(ToolbarService.handleSuggestedResourcesOnAc
  * Handle suggested resources on toolbar icon
  */
 browser.windows.onFocusChanged.addListener(ToolbarService.handleSuggestedResourcesOnFocusedWindow);
+
+browser.webRequest.onAuthRequired.addListener(
+  (details, callback) => BasicAuthService.handle(details).then(callback),
+  { urls: ["<all_urls>"] },
+  ["asyncBlocking"],
+);
+browser.webRequest.onCompleted.addListener((details) => BasicAuthService.clear(details), { urls: ["<all_urls>"] });
+browser.webRequest.onErrorOccurred.addListener((details) => BasicAuthService.clear(details), { urls: ["<all_urls>"] });

--- a/src/chrome-mv3/manifest.json
+++ b/src/chrome-mv3/manifest.json
@@ -5,7 +5,7 @@
   "version": "5.13.4",
   "description": "__MSG_appDescription__",
   "default_locale": "en",
-  "minimum_chrome_version": "116",
+  "minimum_chrome_version": "120",
   "externally_connectable": {
     "ids": []
   },
@@ -42,6 +42,8 @@
     "storage",
     "tabs",
     "scripting",
+    "webRequest",
+    "webRequestAuthProvider",
     "alarms",
     "downloads",
     "cookies",

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -48,6 +48,8 @@
     "tabs",
     "storage",
     "unlimitedStorage",
+    "webRequest",
+    "webRequestBlocking",
     "*://*/*",
     "alarms",
     "cookies"


### PR DESCRIPTION
This pull request adds autofill for basic auth to the passbolt extension. It's more of a temporary patch, than a full stable feature.
When the extension detects a basic auth prompt, it intercepts that requests and automatically logins the user. It uses the credentials from a credential entry saved with a /.htpasswd path.